### PR TITLE
Teardown docker container on `watch` & `watchAll` interruption

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 module.exports = require('./lib/environment');
 module.exports.setup = require('./lib/setup');
+module.exports.teardown = require('./lib/teardown');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
 module.exports = require('./lib/environment');
 module.exports.setup = require('./lib/setup');
-module.exports.teardown = require('./lib/teardown');

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,6 +1,5 @@
 const path = require('path');
 module.exports = {
   globalSetup: path.join(__dirname, 'lib', 'setup.js'),
-  globalTeardown: path.join(__dirname, 'lib', 'teardown.js'),
   testEnvironment: path.join(__dirname, 'lib', 'environment.js'),
 };

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,5 +1,6 @@
 const path = require('path');
 module.exports = {
   globalSetup: path.join(__dirname, 'lib', 'setup.js'),
+  globalTeardown: path.join(__dirname, 'lib', 'teardown.js'),
   testEnvironment: path.join(__dirname, 'lib', 'environment.js'),
 };

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -35,11 +35,6 @@ class DynamodbLocalDockerEnvironment extends NodeEnvironment {
     this.global.deleteTable = deleteTable;
   }
 
-  async teardown() {
-    debug('Tearing down test environment');
-    await super.teardown();
-  }
-
   /** @type {<T = unknown>(script: import('vm').Script) => T} */
   runScript(script) {
     return super.runScript(script);

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -35,6 +35,11 @@ class DynamodbLocalDockerEnvironment extends NodeEnvironment {
     this.global.deleteTable = deleteTable;
   }
 
+  async teardown() {
+    debug('Tearing down test environment');
+    await super.teardown();
+  }
+
   /** @type {<T = unknown>(script: import('vm').Script) => T} */
   runScript(script) {
     return super.runScript(script);

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,7 +2,6 @@
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
 const debug = require('debug')('jest-dynamodb-local-docker');
-const { execSync } = require('child_process');
 const onExit = require('signal-exit');
 
 let didAlreadyRunInWatchMode;
@@ -59,10 +58,10 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-function teardownDynamoDbLocalDocker(jestConfig = {}) {
+async function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
   if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
-    execSync(`docker kill ${containerId}`);
+    await exec(`docker kill ${containerId}`);
   }
   return;
 }

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -8,17 +8,16 @@ const onExit = require('signal-exit');
 let didAlreadyRunInWatchMode;
 
 async function setup(jestConfig = {}) {
-  // If we are in watch mode, - only launchDynamoDbLocalDocker() once, and only setup teardown once.
+  // If we are in watch mode, - only launchDynamoDbLocalDocker() once.
   if (jestConfig.watch || jestConfig.watchAll) {
     if (didAlreadyRunInWatchMode) return;
     didAlreadyRunInWatchMode = true;
   }
 
+  onExit(teardownDynamoDbLocalDocker);
+
   try {
-    const [containerId] = await launchDynamoDbLocalDocker();
-    onExit(() => {
-      execSync(`docker kill ${containerId}`);
-    });
+    await launchDynamoDbLocalDocker();
   } catch (err) {
     console.error(err);
     process.exit(1);
@@ -50,6 +49,7 @@ async function launchDynamoDbLocalDocker() {
     ddbLocalPort = stdout.toString().split('->')[0].split(':')[1];
   }
   await waitFor({ port: ddbLocalPort, retryTimeout: 50 });
+  global[Symbol.for('ddbLocalContainerId')] = ddbLocalContainerId;
   process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT = ddbLocalPort; // expose the port on process.env for helper functions to use because i guess jest provides that to each worker, but the symbol table is unique?
   debug(
     `DynamoDB running on port ${ddbLocalPort} as container id ${ddbLocalContainerId.slice(
@@ -57,7 +57,14 @@ async function launchDynamoDbLocalDocker() {
       12
     )}`
   );
-  return [ddbLocalContainerId, ddbLocalPort];
+}
+
+function teardownDynamoDbLocalDocker(jestConfig = {}) {
+  const containerId = global[Symbol.for('ddbLocalContainerId')];
+  if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
+    execSync(`docker kill ${containerId}`);
+  }
+  return;
 }
 
 function waitFor({
@@ -96,4 +103,5 @@ function waitFor({
 
 module.exports = {
   setup,
+  teardownDynamoDbLocalDocker,
 };

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,6 +2,7 @@
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
 const debug = require('debug')('jest-dynamodb-local-docker');
+const { execSync } = require('child_process');
 const onExit = require('signal-exit');
 
 let didAlreadyRunInWatchMode;
@@ -58,10 +59,10 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-async function teardownDynamoDbLocalDocker(jestConfig = {}) {
+function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
   if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
-    await exec(`docker kill ${containerId}`);
+    execSync(`docker kill ${containerId}`);
   }
   return;
 }

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,6 +2,7 @@
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
 const debug = require('debug')('jest-dynamodb-local-docker');
+const { execSync } = require('child_process');
 const onExit = require('signal-exit');
 
 let didAlreadyRunInWatchMode;
@@ -13,10 +14,7 @@ async function setup(jestConfig = {}) {
     didAlreadyRunInWatchMode = true;
   }
 
-  onExit(async () => {
-    await teardownDynamoDbLocalDocker();
-    process.exit();
-  });
+  onExit(teardownDynamoDbLocalDocker);
 
   try {
     await launchDynamoDbLocalDocker();
@@ -61,10 +59,10 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-async function teardownDynamoDbLocalDocker(jestConfig = {}) {
+function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
   if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
-    await exec(`docker kill ${containerId}`);
+    execSync(`docker kill ${containerId}`);
   }
   return;
 }

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -60,8 +60,6 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-function teardownDynamoDbLocalDocker() {}
-
 function waitFor({
   port = undefined,
   host = undefined,
@@ -98,5 +96,4 @@ function waitFor({
 
 module.exports = {
   setup,
-  teardownDynamoDbLocalDocker,
 };

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -59,23 +59,20 @@ async function launchDynamoDbLocalDocker() {
 let watchModeKillCommandScheduled = false;
 
 // This teardown function runs after every complete test-run
-// In watch mode, this will fire multiple times
+// In watch mode, this will fire each time a change is detected and tests re-run
 async function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
   if (containerId) {
     const killContainer = async () => {
       await exec(`docker kill ${containerId}`);
     };
-    // If we're in watch mode
     if (jestConfig.watch || jestConfig.watchAll) {
-      // And haven't set up our kill command
       if (!watchModeKillCommandScheduled) {
-        onExit(killContainer); // Set the kill command to run on process exit
+        onExit(killContainer); // In watch mode, set the kill command to run on process exit
         watchModeKillCommandScheduled = true; // And then make sure we don't try setting it up again
       }
     } else {
-      // If we're not in watch mode, then testing is complete
-      await killContainer(); // Then kill docker container now
+      await killContainer(); // // If we're not in watch mode, then testing is complete; kill docker container now
     }
   }
 }

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -48,10 +48,8 @@ async function launchDynamoDbLocalDocker() {
   }
   await waitFor({ port: ddbLocalPort, retryTimeout: 50 });
   // once we get a container ID, schedule the container to be killed when the process exits
-  console.log('Scheduling docker container execution');
   onExit(() => {
     execSync(`docker kill ${ddbLocalContainerId}`);
-    console.log('The docker container twitched one last time...goodbye world');
   });
   process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT = ddbLocalPort; // expose the port on process.env for helper functions to use because i guess jest provides that to each worker, but the symbol table is unique?
   debug(
@@ -62,9 +60,7 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-function teardownDynamoDbLocalDocker() {
-  console.log('Jest: "Oh no I am being torn down!"');
-}
+function teardownDynamoDbLocalDocker() {}
 
 function waitFor({
   port = undefined,

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -46,7 +46,12 @@ async function launchDynamoDbLocalDocker() {
     ddbLocalPort = stdout.toString().split('->')[0].split(':')[1];
   }
   await waitFor({ port: ddbLocalPort, retryTimeout: 50 });
-  global[Symbol.for('ddbLocalContainerId')] = ddbLocalContainerId;
+  // once we get a container ID, schedule the container to be killed when the process exits
+  console.log('Scheduling docker container execution');
+  onExit(async () => {
+    console.log('The docker container twitched one last time...goodbye world');
+    await exec(`docker kill ${ddbLocalContainerId}`);
+  });
   process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT = ddbLocalPort; // expose the port on process.env for helper functions to use because i guess jest provides that to each worker, but the symbol table is unique?
   debug(
     `DynamoDB running on port ${ddbLocalPort} as container id ${ddbLocalContainerId.slice(
@@ -56,25 +61,8 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-let watchModeKillCommandScheduled = false;
-
-// This teardown function runs after every complete test-run
-// In watch mode, this will fire each time a change is detected and tests re-run
-async function teardownDynamoDbLocalDocker(jestConfig = {}) {
-  const containerId = global[Symbol.for('ddbLocalContainerId')];
-  if (containerId) {
-    const killContainer = async () => {
-      await exec(`docker kill ${containerId}`);
-    };
-    if (jestConfig.watch || jestConfig.watchAll) {
-      if (!watchModeKillCommandScheduled) {
-        onExit(killContainer); // In watch mode, set the kill command to run on process exit
-        watchModeKillCommandScheduled = true; // And then make sure we don't try setting it up again
-      }
-    } else {
-      await killContainer(); // // If we're not in watch mode, then testing is complete; kill docker container now
-    }
-  }
+function teardownDynamoDbLocalDocker() {
+  console.log('Jest: "Oh no I am being torn down!"');
 }
 
 function waitFor({

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -8,16 +8,17 @@ const onExit = require('signal-exit');
 let didAlreadyRunInWatchMode;
 
 async function setup(jestConfig = {}) {
-  // If we are in watch mode, - only launchDynamoDbLocalDocker() once.
+  // If we are in watch mode, - only launchDynamoDbLocalDocker() once, and only setup teardown once.
   if (jestConfig.watch || jestConfig.watchAll) {
     if (didAlreadyRunInWatchMode) return;
     didAlreadyRunInWatchMode = true;
   }
 
-  onExit(teardownDynamoDbLocalDocker);
-
   try {
-    await launchDynamoDbLocalDocker();
+    const [containerId] = await launchDynamoDbLocalDocker();
+    onExit(() => {
+      execSync(`docker kill ${containerId}`);
+    });
   } catch (err) {
     console.error(err);
     process.exit(1);
@@ -49,7 +50,6 @@ async function launchDynamoDbLocalDocker() {
     ddbLocalPort = stdout.toString().split('->')[0].split(':')[1];
   }
   await waitFor({ port: ddbLocalPort, retryTimeout: 50 });
-  global[Symbol.for('ddbLocalContainerId')] = ddbLocalContainerId;
   process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT = ddbLocalPort; // expose the port on process.env for helper functions to use because i guess jest provides that to each worker, but the symbol table is unique?
   debug(
     `DynamoDB running on port ${ddbLocalPort} as container id ${ddbLocalContainerId.slice(
@@ -57,14 +57,7 @@ async function launchDynamoDbLocalDocker() {
       12
     )}`
   );
-}
-
-function teardownDynamoDbLocalDocker(jestConfig = {}) {
-  const containerId = global[Symbol.for('ddbLocalContainerId')];
-  if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
-    execSync(`docker kill ${containerId}`);
-  }
-  return;
+  return [ddbLocalContainerId, ddbLocalPort];
 }
 
 function waitFor({
@@ -103,5 +96,4 @@ function waitFor({
 
 module.exports = {
   setup,
-  teardownDynamoDbLocalDocker,
 };

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,7 +2,6 @@
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
 const debug = require('debug')('jest-dynamodb-local-docker');
-const { execSync } = require('child_process');
 const onExit = require('signal-exit');
 
 let didAlreadyRunInWatchMode;
@@ -13,8 +12,6 @@ async function setup(jestConfig = {}) {
     if (didAlreadyRunInWatchMode) return;
     didAlreadyRunInWatchMode = true;
   }
-
-  onExit(teardownDynamoDbLocalDocker);
 
   try {
     await launchDynamoDbLocalDocker();
@@ -59,12 +56,18 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
-function teardownDynamoDbLocalDocker(jestConfig = {}) {
+async function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
-  if (containerId && !jestConfig.watch && !jestConfig.watchAll) {
-    execSync(`docker kill ${containerId}`);
+  if (containerId) {
+    const killContainer = async () => {
+      await exec(`docker kill ${containerId}`);
+    };
+    if (jestConfig.watch || jestConfig.watchAll) {
+      onExit(killContainer); // If in watch mode, kill docker container when jest process exits
+    } else {
+      await killContainer(); // If not in watch mode, testing is complete, kill docker container now
+    }
   }
-  return;
 }
 
 function waitFor({

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -56,16 +56,26 @@ async function launchDynamoDbLocalDocker() {
   );
 }
 
+let watchModeKillCommandScheduled = false;
+
+// This teardown function runs after every complete test-run
+// In watch mode, this will fire multiple times
 async function teardownDynamoDbLocalDocker(jestConfig = {}) {
   const containerId = global[Symbol.for('ddbLocalContainerId')];
   if (containerId) {
     const killContainer = async () => {
       await exec(`docker kill ${containerId}`);
     };
+    // If we're in watch mode
     if (jestConfig.watch || jestConfig.watchAll) {
-      onExit(killContainer); // If in watch mode, kill docker container when jest process exits
+      // And haven't set up our kill command
+      if (!watchModeKillCommandScheduled) {
+        onExit(killContainer); // Set the kill command to run on process exit
+        watchModeKillCommandScheduled = true; // And then make sure we don't try setting it up again
+      }
     } else {
-      await killContainer(); // If not in watch mode, testing is complete, kill docker container now
+      // If we're not in watch mode, then testing is complete
+      await killContainer(); // Then kill docker container now
     }
   }
 }

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,6 +2,7 @@
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
 const debug = require('debug')('jest-dynamodb-local-docker');
+const onExit = require('signal-exit');
 
 let didAlreadyRunInWatchMode;
 
@@ -11,6 +12,11 @@ async function setup(jestConfig = {}) {
     if (didAlreadyRunInWatchMode) return;
     didAlreadyRunInWatchMode = true;
   }
+
+  onExit(async () => {
+    await teardownDynamoDbLocalDocker();
+    process.exit();
+  });
 
   try {
     await launchDynamoDbLocalDocker();

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -1,6 +1,7 @@
 // @ts-check
 'use strict';
 const exec = require('util').promisify(require('child_process').exec);
+const { execSync } = require('child_process');
 const debug = require('debug')('jest-dynamodb-local-docker');
 const onExit = require('signal-exit');
 
@@ -48,9 +49,9 @@ async function launchDynamoDbLocalDocker() {
   await waitFor({ port: ddbLocalPort, retryTimeout: 50 });
   // once we get a container ID, schedule the container to be killed when the process exits
   console.log('Scheduling docker container execution');
-  onExit(async () => {
+  onExit(() => {
+    execSync(`docker kill ${ddbLocalContainerId}`);
     console.log('The docker container twitched one last time...goodbye world');
-    await exec(`docker kill ${ddbLocalContainerId}`);
   });
   process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT = ddbLocalPort; // expose the port on process.env for helper functions to use because i guess jest provides that to each worker, but the symbol table is unique?
   debug(

--- a/lib/teardown.js
+++ b/lib/teardown.js
@@ -1,1 +1,0 @@
-module.exports = require('./globals').teardownDynamoDbLocalDocker;

--- a/lib/teardown.js
+++ b/lib/teardown.js
@@ -1,0 +1,1 @@
+module.exports = require('./globals').teardownDynamoDbLocalDocker;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5946,10 +5946,9 @@
       "optional": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "aws-sdk": "^2.764.0",
     "debug": "^4.2.0",
-    "jest-environment-node": "^26.3.0"
+    "jest-environment-node": "^26.3.0",
+    "signal-exit": "^3.0.7"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
There are currently two guards that prevent the docker container from being torn down and set back up on every change. One [in the setup function](https://github.com/danmactough/jest-dynamodb-local-docker/blob/1cde67ec5fd2ddd1150824caef7a1699f7876df7/lib/globals.js#L9-L13) to keep the container from being started on every change, and [one in the teardown function](https://github.com/danmactough/jest-dynamodb-local-docker/blob/1cde67ec5fd2ddd1150824caef7a1699f7876df7/lib/globals.js#L60-L62) to prevent the container from being torn down on every change.

This leads to containers becoming orphaned after interrupting a `watch` session with `q` or `ctrl+c` as they are not torn down.

This PR adds the `signal-exit` package and adds an `onExit` hook that runs `teardownDynamoDbLocalDocker` prior to the jest process exiting in order to clean up the Docker container that was originally created for the `watch` session being cancelled.