### PR TITLE
Increase connectionTimeout for DynamoDB client

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -11,7 +11,7 @@ function getConnectionParams() {
     secretAccessKey: 'test',
     endpoint: `http://localhost:${process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT}`,
     httpOptions: {
-      connectTimeout: 2,
+      connectTimeout: 2000,
     },
     region: 'local',
   };


### PR DESCRIPTION
I believe a 2ms timeout here is a source of test flakiness.