### PR TITLE
Update command-line flags to work with new docker cli behavior

### DIFF
--- a/lib/globals.js
+++ b/lib/globals.js
@@ -42,7 +42,7 @@ async function launchDynamoDbLocalDocker() {
   }
   {
     const { stdout } = await exec(
-      `docker ps -q --filter id=${ddbLocalContainerId} --format '{{.Ports}}'`
+      `docker ps --filter id=${ddbLocalContainerId} --format '{{.Ports}}'`
     );
     ddbLocalPort = stdout.toString().split('->')[0].split(':')[1];
   }


### PR DESCRIPTION
Resolves #4 

Just-released docker cli changed the behavior of docker ps command when passed both -q and --format options. This broke our parsing of that command's output.

This drops the -q to restore the previous behavior. This will not break older docker versions as the -q was previously ignored.