### PR TITLE
Move functions to exports and deprecate globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # jest-dynamodb-local-docker
 
-Jest preset for easily running tests using DynamoDB local
+Jest preset and helper functions for easily running tests using DynamoDB local
 
 ## Usage
 
 See the [tests in this repo](./test/basic.test.js) for example usage.
+
+```js
+const {
+  getDynamodbClient,
+  getDynamodbDocumentClient,
+  createTable,
+  deleteTable,
+} = require('jest-dynamodb-local-docker');
+
+describe('test', () => {
+  beforeAll(async () => {
+    await createTable(/* table properties */);
+  });
+  afterAll(async () => {
+    await deleteTable(/* { tableName: 'table name' } */);
+  });
+  it('should work', async () => {
+    const ddb = getDynamodbDocumentClient(); // or use the standard DynamoDB Client with getDynamodbClient()
+    await ddb.put(/* put request */);
+    await expect(
+      ddb.get(/* get request */)
+    ).toStrictEqual(/* the item we just wrote */);
+  });
+});
+```
 
 ### Add to your Jest setup
 
@@ -19,7 +44,7 @@ Add the `jest-dynamodb-local-docker` [preset to your Jest config](https://jestjs
 }
 ```
 
-### Globals
+### Globals (Deprecated)
 
 - **`global.createTable`** - Creates a DynamoDB table
 - **`global.deleteTable`** - Deletes a DynamoDB table

--- a/index.js
+++ b/index.js
@@ -1,2 +1,13 @@
 module.exports = require('./lib/environment');
 module.exports.setup = require('./lib/setup');
+module.exports.getDynamodbClient = require('./lib/clients').getDynamodbClient;
+module.exports.getDynamodbDocumentClient =
+  require('./lib/clients').getDynamodbDocumentClient;
+module.exports.destroyDynamodbClient =
+  require('./lib/clients').destroyDynamodbClient;
+module.exports.destroyDynanodbDocumentClient =
+  require('./lib/clients').destroyDynanodbDocumentClient;
+module.exports.getConnectionParams =
+  require('./lib/clients').getConnectionParams;
+module.exports.createTable = require('./lib/table-helpers').createTable;
+module.exports.deleteTable = require('./lib/table-helpers').deleteTable;

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -1,0 +1,60 @@
+'use strict';
+const debug = require('debug')('jest-dynamodb-local-docker');
+const { DynamoDB, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
+const { Agent: HttpAgent } = require('http');
+
+const logger = {
+  debug,
+  log: debug,
+  info: debug,
+  warn: debug,
+  error: debug,
+};
+
+function getConnectionParams({ connectionTimeout = 2000 } = {}) {
+  return {
+    accessKeyId: 'test',
+    secretAccessKey: 'test',
+    endpoint: `http://localhost:${process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT}`,
+    requestHandler: new NodeHttpHandler({
+      httpAgent: new HttpAgent(),
+      connectionTimeout,
+    }),
+    logger,
+    region: 'local',
+  };
+}
+
+let ddbClient;
+let ddbDocumentClient;
+
+module.exports = {
+  /** @returns {import('@aws-sdk/client-dynamodb').DynamoDB} */
+  getDynamodbClient() {
+    return ddbClient ?? (ddbClient = new DynamoDB(getConnectionParams()));
+  },
+  destroyDynamodbClient() {
+    if (ddbClient) {
+      ddbClient.destroy();
+    }
+    ddbClient = undefined;
+  },
+  /** @returns {import('@aws-sdk/lib-dynamodb').DynamoDBDocument} */
+  getDynamodbDocumentClient() {
+    return (
+      ddbDocumentClient ??
+      (ddbDocumentClient = DynamoDBDocument.from(
+        new DynamoDBClient(getConnectionParams())
+      ))
+    );
+  },
+  destroyDynanodbDocumentClient() {
+    if (ddbDocumentClient) {
+      ddbDocumentClient.destroy();
+    }
+    ddbDocumentClient = undefined;
+  },
+  getConnectionParams,
+};

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,120 +1,44 @@
 // @ts-check
 'use strict';
+const util = require('node:util');
 const { default: NodeEnvironment } = require('jest-environment-node');
-const expect = require('expect');
 const debug = require('debug')('jest-dynamodb-local-docker');
 const {
-  DynamoDB,
-  DynamoDBClient,
-  waitUntilTableExists,
-  BillingMode,
-} = require('@aws-sdk/client-dynamodb');
-const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
-const { NodeHttpHandler } = require('@smithy/node-http-handler');
-const { Agent: HttpAgent } = require('http');
-
-const logger = {
-  debug,
-  log: debug,
-  info: debug,
-  warn: debug,
-  error: debug,
-};
-// Logging out the error will help a user diagnose any setup issues more quickly,
-// and from experience, a user won't do it, so we'll handle the error,
-// log it, and then rethrow it.
-const errHandler = (err) => {
-  console.error(err);
-  throw err;
-};
-
-function getConnectionParams() {
-  return {
-    accessKeyId: 'test',
-    secretAccessKey: 'test',
-    endpoint: `http://localhost:${process.env.__JEST_DYNAMODB_LOCAL_DOCKER__PORT}`,
-    requestHandler: new NodeHttpHandler({
-      httpAgent: new HttpAgent(),
-      connectionTimeout: 2000,
-    }),
-    logger,
-    region: 'local',
-  };
-}
+  getDynamodbClient,
+  getDynamodbDocumentClient,
+  destroyDynamodbClient,
+  destroyDynanodbDocumentClient,
+} = require('./clients');
+const { createTable, deleteTable } = require('./table-helpers');
 
 class DynamodbLocalDockerEnvironment extends NodeEnvironment {
-  constructor(config, _context) {
-    super(config, _context);
-    this.ddbClient = new DynamoDB(getConnectionParams());
-    this.ddbDocumentClient = DynamoDBDocument.from(
-      new DynamoDBClient(getConnectionParams())
-    );
-  }
-
   async setup() {
     debug('Setting up test environment');
     await super.setup();
-    /** @returns {import('@aws-sdk/client-dynamodb').DynamoDB} */
-    this.global.getDynamodbClient = () => this.ddbClient;
-    /** @returns {import('@aws-sdk/lib-dynamodb').DynamoDBDocument} */
-    this.global.getDynamodbDocumentClient = () => this.ddbDocumentClient;
-    this.global.createTable = createTable;
-    this.global.deleteTable = deleteTable;
+    this.global.getDynamodbClient = util.deprecate(
+      getDynamodbClient,
+      `global.getDynamodbClient is deprecated and will be removed in the next major version release. Use const { getDynamodbClient } = require('jest-dynamodb-local-docker') instead.`
+    );
+    this.global.getDynamodbDocumentClient = util.deprecate(
+      getDynamodbDocumentClient,
+      `global.getDynamodbDocumentClient is deprecated and will be removed in the next major version release. Use const { getDynamodbDocumentClient } = require('jest-dynamodb-local-docker') instead.`
+    );
+    this.global.createTable = util.deprecate(
+      createTable,
+      `global.createTable is deprecated and will be removed in the next major version release. Use const { createTable } = require('jest-dynamodb-local-docker') instead.`
+    );
+    this.global.deleteTable = util.deprecate(
+      deleteTable,
+      `global.deleteTable is deprecated and will be removed in the next major version release. Use const { deleteTable } = require('jest-dynamodb-local-docker') instead.`
+    );
   }
-}
 
-/**
- * @param {object} params
- * @param {import('@aws-sdk/client-dynamodb').CreateTableInput} params.tableProperties
- * @returns {Promise<void>}
- */
-async function createTable({ tableProperties }) {
-  const ddb = new DynamoDB(getConnectionParams());
-  const { TableName } = tableProperties;
-  try {
-    // We won't use our errHandler on describeTable because we expect to see
-    // lots of `ResourceNotFoundException` errors that are not _actually_ errors.
-    const { Table: table } = await ddb.describeTable({ TableName });
-    if (table.TableStatus !== 'ACTIVE') {
-      throw new Error(
-        `Table ${TableName} status is ${
-          table.TableStatus || 'not ACTIVE'
-        }. unable to proceed`
-      );
-    }
-    // @ts-ignore
-    expect(table).toMatchObject(tableProperties);
-  } catch (e) {
-    // Table does not exist. Create it.
-    if (e.name === 'ResourceNotFoundException') {
-      const params = {
-        ...tableProperties,
-        TableName,
-        BillingMode: BillingMode.PAY_PER_REQUEST,
-      };
-      await ddb.createTable(params).catch(errHandler);
-      await waitUntilTableExists(
-        { client: ddb, maxWaitTime: 60 },
-        { TableName }
-      ).catch(errHandler);
-      debug(`Table ${TableName} is ready`);
-    } else {
-      // Because we aren't using our errHandler on describeTable, we will
-      // manually log the error before rethrowing it.
-      console.error(e);
-      throw e;
-    }
+  async teardown() {
+    debug('Tearing down test environment');
+    destroyDynamodbClient();
+    destroyDynanodbDocumentClient();
+    await super.teardown();
   }
-}
-
-/**
- * @param {object} params
- * @param {string} params.tableName
- * @returns {Promise<void>}
- */
-async function deleteTable({ tableName: TableName }) {
-  const ddb = new DynamoDB(getConnectionParams());
-  await ddb.deleteTable({ TableName }).catch(errHandler);
 }
 
 module.exports = DynamodbLocalDockerEnvironment;

--- a/lib/table-helpers.js
+++ b/lib/table-helpers.js
@@ -1,0 +1,75 @@
+'use strict';
+const expect = require('expect');
+const debug = require('debug')('jest-dynamodb-local-docker');
+const {
+  waitUntilTableExists,
+  BillingMode,
+} = require('@aws-sdk/client-dynamodb');
+const { getDynamodbClient } = require('./clients');
+
+// Logging out the error will help a user diagnose any setup issues more quickly,
+// and from experience, a user won't do it, so we'll handle the error,
+// log it, and then rethrow it.
+const errHandler = (err) => {
+  console.error(err);
+  throw err;
+};
+
+/**
+ * @param {object} params
+ * @param {import('@aws-sdk/client-dynamodb').CreateTableInput} params.tableProperties
+ * @returns {Promise<void>}
+ */
+async function createTable({ tableProperties }) {
+  const ddb = getDynamodbClient();
+  const { TableName } = tableProperties;
+  try {
+    // We won't use our errHandler on describeTable because we expect to see
+    // lots of `ResourceNotFoundException` errors that are not _actually_ errors.
+    const { Table: table } = await ddb.describeTable({ TableName });
+    if (table.TableStatus !== 'ACTIVE') {
+      throw new Error(
+        `Table ${TableName} status is ${
+          table.TableStatus || 'not ACTIVE'
+        }. unable to proceed`
+      );
+    }
+    // @ts-ignore
+    expect(table).toMatchObject(tableProperties);
+  } catch (e) {
+    // Table does not exist. Create it.
+    if (e.name === 'ResourceNotFoundException') {
+      const params = {
+        ...tableProperties,
+        TableName,
+        BillingMode: BillingMode.PAY_PER_REQUEST,
+      };
+      await ddb.createTable(params).catch(errHandler);
+      await waitUntilTableExists(
+        { client: ddb, maxWaitTime: 60 },
+        { TableName }
+      ).catch(errHandler);
+      debug(`Table ${TableName} is ready`);
+    } else {
+      // Because we aren't using our errHandler on describeTable, we will
+      // manually log the error before rethrowing it.
+      console.error(e);
+      throw e;
+    }
+  }
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.tableName
+ * @returns {Promise<void>}
+ */
+async function deleteTable({ tableName: TableName }) {
+  const ddb = getDynamodbClient();
+  await ddb.deleteTable({ TableName }).catch(errHandler);
+}
+
+module.exports = {
+  createTable,
+  deleteTable,
+};

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,3 +1,12 @@
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const {
+  getDynamodbClient,
+  getDynamodbDocumentClient,
+  createTable,
+  deleteTable,
+} = require('..');
+
 describe('basic', () => {
   it('should define our globals', () => {
     expect(global.getDynamodbClient).toEqual(expect.any(Function));
@@ -5,10 +14,143 @@ describe('basic', () => {
     expect(global.createTable).toEqual(expect.any(Function));
     expect(global.deleteTable).toEqual(expect.any(Function));
   });
+  it('should deprecate our globals', () => {
+    expect(global.getDynamodbClient.name).toEqual('deprecated');
+    expect(global.getDynamodbDocumentClient.name).toEqual('deprecated');
+    expect(global.createTable.name).toEqual('deprecated');
+    expect(global.deleteTable.name).toEqual('deprecated');
+  });
+});
+describe('globals', () => {
+  describe('getDynamodbClient', () => {
+    it('should return a DynamoDB client', () => {
+      const ddbClient = global.getDynamodbClient();
+      expect(ddbClient.batchGetItem).toEqual(expect.any(Function));
+      expect(ddbClient.batchWriteItem).toEqual(expect.any(Function));
+      expect(ddbClient.deleteItem).toEqual(expect.any(Function));
+      expect(ddbClient.getItem).toEqual(expect.any(Function));
+      expect(ddbClient.putItem).toEqual(expect.any(Function));
+      expect(ddbClient.query).toEqual(expect.any(Function));
+      expect(ddbClient.scan).toEqual(expect.any(Function));
+      expect(ddbClient.updateItem).toEqual(expect.any(Function));
+      expect(ddbClient.transactGetItems).toEqual(expect.any(Function));
+      expect(ddbClient.transactWriteItems).toEqual(expect.any(Function));
+    });
+  });
+  describe('getDynamodbDocumentClient', () => {
+    it('should return a DynamoDB.DocumentClient client', () => {
+      const ddbClient = global.getDynamodbDocumentClient();
+      expect(ddbClient.batchGet).toEqual(expect.any(Function));
+      expect(ddbClient.batchWrite).toEqual(expect.any(Function));
+      expect(ddbClient.delete).toEqual(expect.any(Function));
+      expect(ddbClient.get).toEqual(expect.any(Function));
+      expect(ddbClient.put).toEqual(expect.any(Function));
+      expect(ddbClient.query).toEqual(expect.any(Function));
+      expect(ddbClient.scan).toEqual(expect.any(Function));
+      expect(ddbClient.update).toEqual(expect.any(Function));
+      expect(ddbClient.transactGet).toEqual(expect.any(Function));
+      expect(ddbClient.transactWrite).toEqual(expect.any(Function));
+    });
+  });
+  describe('createTable', () => {
+    const tableName = 'createTable_test';
+    afterEach(async () => {
+      await global.deleteTable({ tableName });
+    });
+    it('should create a table', async () => {
+      const tableProperties = {
+        TableName: tableName,
+        AttributeDefinitions: [
+          {
+            AttributeName: 'partition',
+            AttributeType: 'S',
+          },
+          {
+            AttributeName: 'sort',
+            AttributeType: 'S',
+          },
+        ],
+        KeySchema: [
+          {
+            AttributeName: 'partition',
+            KeyType: 'HASH',
+          },
+          {
+            AttributeName: 'sort',
+            KeyType: 'RANGE',
+          },
+        ],
+      };
+      const ddbClient = global.getDynamodbDocumentClient();
+      await expect(
+        global.createTable({ tableProperties })
+      ).resolves.toBeUndefined();
+      await expect(
+        ddbClient.put({
+          TableName: tableName,
+          Item: { partition: 'abc', sort: '1' },
+        })
+      ).resolves.toEqual(expect.anything());
+      await expect(
+        ddbClient.get({
+          TableName: tableName,
+          Key: {
+            partition: 'abc',
+            sort: '1',
+          },
+        })
+      ).resolves.toMatchInlineSnapshot(
+        { $metadata: expect.any(Object) },
+        `
+      {
+        "$metadata": Any<Object>,
+        "Item": {
+          "partition": "abc",
+          "sort": "1",
+        },
+      }
+    `
+      );
+    });
+  });
+  describe('deleteTable', () => {
+    const tableName = 'createTable_test';
+    beforeEach(async () => {
+      const tableProperties = {
+        TableName: tableName,
+        AttributeDefinitions: [
+          {
+            AttributeName: 'partition',
+            AttributeType: 'S',
+          },
+          {
+            AttributeName: 'sort',
+            AttributeType: 'S',
+          },
+        ],
+        KeySchema: [
+          {
+            AttributeName: 'partition',
+            KeyType: 'HASH',
+          },
+          {
+            AttributeName: 'sort',
+            KeyType: 'RANGE',
+          },
+        ],
+      };
+      await expect(
+        global.createTable({ tableProperties })
+      ).resolves.toBeUndefined();
+    });
+    it('should delete a table', async () => {
+      await expect(global.deleteTable({ tableName })).resolves.toBeUndefined();
+    });
+  });
 });
 describe('getDynamodbClient', () => {
   it('should return a DynamoDB client', () => {
-    const ddbClient = global.getDynamodbClient();
+    const ddbClient = getDynamodbClient();
     expect(ddbClient.batchGetItem).toEqual(expect.any(Function));
     expect(ddbClient.batchWriteItem).toEqual(expect.any(Function));
     expect(ddbClient.deleteItem).toEqual(expect.any(Function));
@@ -23,7 +165,7 @@ describe('getDynamodbClient', () => {
 });
 describe('getDynamodbDocumentClient', () => {
   it('should return a DynamoDB.DocumentClient client', () => {
-    const ddbClient = global.getDynamodbDocumentClient();
+    const ddbClient = getDynamodbDocumentClient();
     expect(ddbClient.batchGet).toEqual(expect.any(Function));
     expect(ddbClient.batchWrite).toEqual(expect.any(Function));
     expect(ddbClient.delete).toEqual(expect.any(Function));
@@ -39,7 +181,7 @@ describe('getDynamodbDocumentClient', () => {
 describe('createTable', () => {
   const tableName = 'createTable_test';
   afterEach(async () => {
-    await global.deleteTable({ tableName });
+    await deleteTable({ tableName });
   });
   it('should create a table', async () => {
     const tableProperties = {
@@ -65,10 +207,8 @@ describe('createTable', () => {
         },
       ],
     };
-    const ddbClient = global.getDynamodbDocumentClient();
-    await expect(
-      global.createTable({ tableProperties })
-    ).resolves.toBeUndefined();
+    const ddbClient = getDynamodbDocumentClient();
+    await expect(createTable({ tableProperties })).resolves.toBeUndefined();
     await expect(
       ddbClient.put({
         TableName: tableName,
@@ -123,11 +263,25 @@ describe('deleteTable', () => {
         },
       ],
     };
-    await expect(
-      global.createTable({ tableProperties })
-    ).resolves.toBeUndefined();
+    await expect(createTable({ tableProperties })).resolves.toBeUndefined();
   });
   it('should delete a table', async () => {
-    await expect(global.deleteTable({ tableName })).resolves.toBeUndefined();
+    await expect(deleteTable({ tableName })).resolves.toBeUndefined();
+  });
+});
+describe('client identity', () => {
+  describe('DynamoDB', () => {
+    it('should pass instanceof test', () => {
+      expect(global.getDynamodbClient()).not.toBeInstanceOf(DynamoDB);
+      expect(getDynamodbClient()).toBeInstanceOf(DynamoDB);
+    });
+  });
+  describe('DynamoDBDocument', () => {
+    it('should pass instanceof test', () => {
+      expect(global.getDynamodbDocumentClient()).not.toBeInstanceOf(
+        DynamoDBDocument
+      );
+      expect(getDynamodbDocumentClient()).toBeInstanceOf(DynamoDBDocument);
+    });
   });
 });


### PR DESCRIPTION
The aws-sdk v3 provides a nice paginator for queries and scans. Unfortunately, it [contains an `instanceof` check](https://github.com/smithy-lang/smithy-typescript/blob/12d9afe28b7b0b0868f30425f0181586e06122ce/packages/core/src/pagination/createPaginator.ts#L45), which is unbearably problematic for Jest to deal with because it of the way it runs tests in a VM (which you can disable with `--runInBand`) and uses a custom module loader (which is much more difficult to disable) that leads to different instances (no pun intended) of a module cache. (See https://backend.cafe/should-you-use-jest-as-a-testing-library). Specifically, this means that the `DynamoDBDocument` class that the `global.getDynamodbDocumentClient` returns is created with a different copy than the one the `paginateQuery` aws sdk function uses for an `instanceof` check. So it fails. Which means you can't test any code using `paginateQuery` or `paginateScan`.

Not ok. 👎🏻 

This PR resolves the problem by exposing `getDynamodbDocumentClient` (and the other globals) on `module.exports`. So instead of carrying around a an instance of an object created with a different copy of the `DynamoDBDocument` (because it's not created in the context of the test), using `getDynamodbDocumentClient` like a normal library function means both the client and `paginateQuery`/`paginateScan` will use the same copy of the `DynamoDBDocument` class, and the `instanceof` checks will succeed. See the new "client identity" tests for validation.

And since using the globals was always kind of icky anyway, this PR makes them deprecated in the docs and with a warning. We'll remove the globals altogether in v4.